### PR TITLE
Fix duplicated clips

### DIFF
--- a/kindle.py
+++ b/kindle.py
@@ -80,7 +80,7 @@ def main():
     for section in sections:
         clip = get_clip(section)
         if clip:
-            clips[clip['book']][clip['position']] = clip['content']
+            clips[clip['book']][str(clip['position'])] = clip['content']
 
     # remove key with empty value
     clips = {k: v for k, v in clips.iteritems() if v}


### PR DESCRIPTION
Integer as key is not allowed in JSON, after a save then load of
`clips.json` there may be duplicated keys:

- `clips["some-book"]["101"]`
- `clips["some-book"][101]`

It leads to duplicated clips in output.

This is actually my fault via https://github.com/lxyu/kindle-clippings/pull/3 😂 