### PR TITLE
Leveraging io.open to archive compatible across Python2&3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.txt
 clips.json
 .DS_Store
+output

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -5,11 +5,50 @@ from tinydb import TinyDB , Query
 class KindleClippingDB(object):
 
     def __init__(self, db_path):
-        self.db = TinyDB(db_path)
-        self.books = db.table('books')
-        self.highlights = db.table('highlights')
+        self.db = TinyDB(db_path,sort_keys=False, indent=4, ensure_ascii=False,allow_nan=False)
+        self.books = self.db.table('books')
+        self.highlights = self.db.table('highlights')
 
     def pure_all(self):
-        self.purge_tables()
+        self.db.purge_tables()
 
-    def add_book(self, title , author )
+    def add_book(self, title , author ,other_attrs = {}):
+        doc = dict(other_attrs)
+        doc['title'] = title
+        doc['author'] = author if author else ""
+        id = self.books.insert(doc)
+        return id
+    
+    def _add_highlight(self,book_id,content,pos_start,pos_end,datetime_epoch,other_attrs):
+        doc = dict(other_attrs)
+        doc['book_id'] = book_id
+        doc['content'] = content
+        doc['pos_start'] = pos_start
+        doc['pos_end'] = pos_end if pos_end else 0
+        doc['datetime_epoch'] = datetime_epoch if datetime_epoch else 0
+        id =  self.highlights.insert(doc)
+        return id
+
+    def add_highlight(self,content,book_title,book_author,pos_start,pos_end,datetime_epoch,other_attrs = {}):
+        book = self.query_book(book_title,book_author)
+        book_id = None
+        if book :
+            book_id = book.doc_id
+        else:
+            book_id = self.add_book(book_title,book_author)
+        id = self._add_highlight(book_id,content,pos_start,pos_end,datetime_epoch,other_attrs)
+        return id
+
+    def query_book(self,title,author):
+        bookQ = Query()
+        res = self.books.search((bookQ.title == title) & (bookQ.author == author))
+        assert( len(res) <= 1)
+        return res[0] if len(res) > 0 else None 
+
+    def get_highligts_by_book(self,book_title,book_author):
+        book = self.query_book(book_title,book_author)
+        if not book:
+            return
+        res = self.highlights.search(Query().book_id == book.doc_id)
+        return res
+    

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -19,7 +19,7 @@ class KindleClippingDB(object):
         id = self.books.insert(doc)
         return id
     
-    def _add_highlight(self,book_id,content,datetime_epoch,pos_start,pos_end,other_attrs):
+    def _add_highlight(self,book_id,content,epoch,pos_start,pos_end,other_attrs):
         hQ = Query()
         res = self.highlights.search((hQ.book_id == book_id) & (hQ.content == content))
         if len(res) > 0:
@@ -29,18 +29,18 @@ class KindleClippingDB(object):
         doc['content'] = content
         doc['pos_start'] = pos_start if pos_start else 0 
         doc['pos_end'] = pos_end if pos_end else 0
-        doc['datetime_epoch'] = datetime_epoch if datetime_epoch else 0
+        doc['epoch'] = epoch if epoch else 0
         id =  self.highlights.insert(doc)
         return id
 
-    def add_highlight(self,content,book_title,book_author,datetime_epoch,pos_start = None,pos_end = None,other_attrs = {}):
+    def add_highlight(self,content,book_title,book_author,epoch,pos_start = None,pos_end = None,other_attrs = {}):
         res = self.query_book(book_title,book_author)
         book_id = None
         if len(res)>0 :
             book_id = res[0].doc_id
         else:
             book_id = self.add_book(book_title,book_author)
-        id = self._add_highlight(book_id,content,datetime_epoch,pos_start,pos_end,other_attrs)
+        id = self._add_highlight(book_id,content,epoch,pos_start,pos_end,other_attrs)
         return id
 
     def query_book(self,title,author):

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -75,7 +75,7 @@ class KindleClippingDB(object):
 
     def query_books(self, query_string):
         if (query_string == None or len(query_string) < 1):
-           res = self.books.all();
+           res = self.books.all()
         else:
            bookQ = Query()
            res = self.books.search((bookQ.title.search(query_string ,flags=re.IGNORECASE )) | ( bookQ.author.search(query_string ,flags=re.IGNORECASE)))

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -5,7 +5,7 @@ from tinydb import TinyDB , Query
 class KindleClippingDB(object):
 
     def __init__(self, db_path):
-        self.db = TinyDB(db_path,sort_keys=True, indent=4, ensure_ascii=False,allow_nan=False)
+        self.db = TinyDB(db_path,sort_keys=True, indent=4, ensure_ascii=False,allow_nan=False,encoding='utf-8')
         self.books = self.db.table('books')
         self.highlights = self.db.table('highlights')
 

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -20,6 +20,10 @@ class KindleClippingDB(object):
         return id
     
     def _add_highlight(self,book_id,content,pos_start,pos_end,datetime_epoch,other_attrs):
+        hQ = Query()
+        res = self.highlights.search((hQ.book_id == book_id) & (hQ.content == content))
+        if len(res) > 0:
+            return res[0].doc_id 
         doc = dict(other_attrs)
         doc['book_id'] = book_id
         doc['content'] = content

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -7,7 +7,7 @@ class KindleClippingDB(object):
 
     def __init__(self, db_path):
         self.db = TinyDB(db_path, sort_keys=True, indent=4,
-                         ensure_ascii=False, allow_nan=False, encoding='utf-8')
+                         ensure_ascii=False, encoding='utf-8')
         self.books = self.db.table('books')
         self.highlights = self.db.table('highlights')
 

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -43,7 +43,7 @@ class KindleClippingDB(object):
         id = self._add_highlight(book_id,content,epoch,pos_start,pos_end,other_attrs)
         return id
 
-    def query_book(self,title,author):
+    def query_book(self,title = None,author = None):
         bookQ = Query()
         def author_name_matcher(db_value,input_value):
             db_names = set([x for x in re.split(r'\s|,', db_value) if len(x)>0])
@@ -57,9 +57,17 @@ class KindleClippingDB(object):
                 return True
             else:
                 return False 
-        res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher,author)))
-        if (len(res) < 1):
-            res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher_fallback,author)))
+        res = []
+        if title and author :
+            res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher,author)))
+            if (len(res) < 1):
+                res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher_fallback,author)))
+        elif title :
+            res = self.books.search((bookQ.title == title))
+        elif author:
+            res = self.books.search((bookQ.author.test(author_name_matcher,author)))
+            if (len(res) < 1):
+                res = self.books.search((bookQ.author.test(author_name_matcher_fallback,author)))
         return res
 
     def get_highligts_by_book(self,book_title,book_author,book_query = None):

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -1,85 +1,98 @@
 # -*- coding: utf-8 -*-
 import re
-from tinydb import TinyDB , Query
+from tinydb import TinyDB, Query
+
 
 class KindleClippingDB(object):
 
     def __init__(self, db_path):
-        self.db = TinyDB(db_path,sort_keys=True, indent=4, ensure_ascii=False,allow_nan=False,encoding='utf-8')
+        self.db = TinyDB(db_path, sort_keys=True, indent=4,
+                         ensure_ascii=False, allow_nan=False, encoding='utf-8')
         self.books = self.db.table('books')
         self.highlights = self.db.table('highlights')
 
     def pure_all(self):
         self.db.purge_tables()
 
-    def add_book(self, title , author ,other_attrs = {}):
+    def add_book(self, title, author, other_attrs={}):
         doc = dict(other_attrs)
         doc['title'] = title
         doc['author'] = author if author else ""
         id = self.books.insert(doc)
         return id
-    
-    def _add_highlight(self,book_id,content,epoch,pos_start,pos_end,other_attrs):
+
+    def _add_highlight(self, book_id, content, epoch, pos_start, pos_end, other_attrs):
         hQ = Query()
-        res = self.highlights.search((hQ.book_id == book_id) & (hQ.content == content))
+        res = self.highlights.search(
+            (hQ.book_id == book_id) & (hQ.content == content))
         if len(res) > 0:
-            return res[0].doc_id 
+            return res[0].doc_id
         doc = dict(other_attrs)
         doc['book_id'] = book_id
         doc['content'] = content
-        doc['pos_start'] = pos_start if pos_start else 0 
+        doc['pos_start'] = pos_start if pos_start else 0
         doc['pos_end'] = pos_end if pos_end else 0
         doc['epoch'] = epoch if epoch else 0
-        id =  self.highlights.insert(doc)
+        id = self.highlights.insert(doc)
         return id
 
-    def add_highlight(self,content,book_title,book_author,epoch,pos_start = None,pos_end = None,other_attrs = {}):
-        res = self.query_book(book_title,book_author)
+    def add_highlight(self, content, book_title, book_author, epoch, pos_start=None, pos_end=None, other_attrs={}):
+        res = self.get_books(book_title, book_author)
         book_id = None
-        if len(res)>0 :
+        if len(res) > 0:
             book_id = res[0].doc_id
         else:
-            book_id = self.add_book(book_title,book_author)
-        id = self._add_highlight(book_id,content,epoch,pos_start,pos_end,other_attrs)
+            book_id = self.add_book(book_title, book_author)
+        id = self._add_highlight(
+            book_id, content, epoch, pos_start, pos_end, other_attrs)
         return id
 
-    def query_book(self,title = None,author = None):
+    def get_books(self, title, author):
         bookQ = Query()
-        def author_name_matcher(db_value,input_value):
-            db_names = set([x for x in re.split(r'\s|,', db_value) if len(x)>0])
-            input_names = set([x for x in re.split(r'\s|,', input_value) if len(x)>0])
+
+        def author_name_matcher(db_value, input_value):
+            db_names = set([x for x in re.split(
+                r'\s|,', db_value) if len(x) > 0])
+            input_names = set([x for x in re.split(
+                r'\s|,', input_value) if len(x) > 0])
             return db_names == input_names
 
-        def author_name_matcher_fallback(db_value,input_value):
+        def author_name_matcher_fallback(db_value, input_value):
             db_value = db_value.lower()
             input_value = input_value.lower()
-            if ( db_value.find(input_value) != -1 or input_value.find(db_value) != -1):
+            if (db_value.find(input_value) != -1 or input_value.find(db_value) != -1):
                 return True
             else:
-                return False 
-        res = []
-        if title and author :
-            res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher,author)))
-            if (len(res) < 1):
-                res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher_fallback,author)))
-        elif title :
-            res = self.books.search((bookQ.title == title))
-        elif author:
-            res = self.books.search((bookQ.author.test(author_name_matcher,author)))
-            if (len(res) < 1):
-                res = self.books.search((bookQ.author.test(author_name_matcher_fallback,author)))
+                return False
+
+        res = self.books.search((bookQ.title == title) & (
+            bookQ.author.test(author_name_matcher, author)))
+        if (len(res) < 1):
+            res = self.books.search((bookQ.title == title) & (
+                bookQ.author.test(author_name_matcher_fallback, author)))
+
         return res
 
-    def get_highligts_by_book(self,book_title,book_author,book_query = None):
-        books = self.query_book(book_title,book_author)
-        if not books :
+    def query_books(self, query_string):
+        if (query_string == None or len(query_string) < 1):
+           res = self.books.all();
+        else:
+           bookQ = Query()
+           res = self.books.search((bookQ.title.search(query_string ,flags=re.IGNORECASE )) | ( bookQ.author.search(query_string ,flags=re.IGNORECASE)))
+
+        return res
+
+    def get_highligts_by_book(self, book_title, book_author, book_query=None):
+        books = self.get_books(book_title, book_author)
+        if not books:
             return []
         res = []
         for b in books:
             if book_query:
-                q = (((Query().book_id == b.doc_id) & book_query) & ( ~ Query().hidden_mark.exists() ))
+                q = (((Query().book_id == b.doc_id) & book_query)
+                     & (~ Query().hidden_mark.exists()))
             else:
-                q = ((Query().book_id == b.doc_id)  &  ( ~ Query().hidden_mark.exists() ) )
+                q = ((Query().book_id == b.doc_id) &
+                     (~ Query().hidden_mark.exists()))
             res.extend(self.highlights.search(q))
         return res
-    

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -5,7 +5,7 @@ from tinydb import TinyDB , Query
 class KindleClippingDB(object):
 
     def __init__(self, db_path):
-        self.db = TinyDB(db_path,sort_keys=False, indent=4, ensure_ascii=False,allow_nan=False)
+        self.db = TinyDB(db_path,sort_keys=True, indent=4, ensure_ascii=False,allow_nan=False)
         self.books = self.db.table('books')
         self.highlights = self.db.table('highlights')
 

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -49,7 +49,17 @@ class KindleClippingDB(object):
             db_names = set([x for x in re.split(r'\s|,', db_value) if len(x)>0])
             input_names = set([x for x in re.split(r'\s|,', input_value) if len(x)>0])
             return db_names == input_names
+
+        def author_name_matcher_fallback(db_value,input_value):
+            db_value = db_value.lower()
+            input_value = input_value.lower()
+            if ( db_value.find(input_value) != -1 or input_value.find(db_value) != -1):
+                return True
+            else:
+                return False 
         res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher,author)))
+        if (len(res) < 1):
+            res = self.books.search((bookQ.title == title) & (bookQ.author.test(author_name_matcher_fallback,author)))
         return res
 
     def get_highligts_by_book(self,book_title,book_author,book_query = None):

--- a/db_adapter.py
+++ b/db_adapter.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from tinydb import TinyDB , Query
+
+class KindleClippingDB(object):
+
+    def __init__(self, db_path):
+        self.db = TinyDB(db_path)
+        self.books = db.table('books')
+        self.highlights = db.table('highlights')
+
+    def pure_all(self):
+        self.purge_tables()
+
+    def add_book(self, title , author )

--- a/kindle.py
+++ b/kindle.py
@@ -8,6 +8,7 @@ import re
 import json
 import argparse
 import dateparser
+from tinydb import Query
 if __name__ == '__main__':
     from db_adapter import KindleClippingDB
 else:
@@ -75,11 +76,11 @@ def main(kindle_clippings_file_path, json_db_path , is_overwrite):
     #import ipdb; ipdb.set_trace()        
     sections = get_sections(kindle_clippings_file_path)
     with db.db:
-        all_highlights = db.highlights.all()
+        all_imported_highlights = db.highlights.search( (~ Query().not_by_imported.exists() ) )
         latest_epoch = 0
-        if len(all_highlights) > 0:
-            sorted(all_highlights,key = lambda h : h['datetime_epoch'])
-            latest_epoch = all_highlights[-1]['datetime_epoch']
+        if len(all_imported_highlights) > 0:
+            sorted(all_imported_highlights,key = lambda h : h['datetime_epoch'])
+            latest_epoch = all_imported_highlights[-1]['datetime_epoch']
         for section in sections:
             clip = get_clip(section)
             try:

--- a/kindle.py
+++ b/kindle.py
@@ -8,7 +8,10 @@ import re
 import json
 import argparse
 import dateparser
-import db_adapter
+if __name__ == '__main__':
+    from db_adapter import KindleClippingDB
+else:
+    from .db_adapter import KindleClippingDB
 
 BOUNDARY = u"=========="
 
@@ -69,7 +72,7 @@ def get_clip(section):
 
 
 def main(kindle_clippings_file_path, json_db_path , is_overwrite):
-    db = db_adapter.KindleClippingDB(json_db_path)
+    db = KindleClippingDB(json_db_path)
 
     if is_overwrite:
         db.pure_all()
@@ -87,6 +90,7 @@ def main(kindle_clippings_file_path, json_db_path , is_overwrite):
 
 
 if __name__ == '__main__':
+    
     parser = argparse.ArgumentParser(description='Kindle clipping to JSON parser')
     parser.add_argument('clippings_file',type=str ,help="Kindle My Clippings.txt file path")
     parser.add_argument('--overwrite' , nargs='?', const='True', help="By defult your new JSON file will based on previous parsed JSON,if you have assigned this argument new content will overwrite old one.")

--- a/kindle.py
+++ b/kindle.py
@@ -5,15 +5,17 @@ import collections
 import json
 import os
 import re
+from io import open
 
-BOUNDARY = u"==========\r\n"
+
+BOUNDARY = u"=========="
 DATA_FILE = u"clips.json"
 OUTPUT_DIR = u"output"
 
 
 def get_sections(filename):
-    with open(filename, 'rb') as f:
-        content = f.read().decode('utf-8')
+    with open(filename, 'r',encoding='utf8') as f:
+        content = f.read()
     content = content.replace(u'\ufeff', u'')
     return content.split(BOUNDARY)
 
@@ -21,7 +23,7 @@ def get_sections(filename):
 def get_clip(section):
     clip = {}
 
-    lines = [l for l in section.split(u'\r\n') if l]
+    lines = [l for l in section.split(u'\n') if l]
     if len(lines) != 3:
         return
 
@@ -44,10 +46,10 @@ def export_txt(clips):
     for book in clips:
         lines = []
         for pos in sorted(clips[book]):
-            lines.append(clips[book][pos].encode('utf-8'))
+            lines.append(clips[book][pos])
 
         filename = os.path.join(OUTPUT_DIR, u"%s.md" % book)
-        with open(filename, 'wb') as f:
+        with open(filename, 'w',encoding='utf8') as f:
             f.write("\n\n---\n\n".join(lines))
 
 
@@ -56,18 +58,18 @@ def load_clips():
     Load previous clips from DATA_FILE
     """
     try:
-        with open(DATA_FILE, 'rb') as f:
+        with open(DATA_FILE, 'r',encoding='utf8') as f:
             return json.load(f)
     except (IOError, ValueError):
         return {}
-
 
 def save_clips(clips):
     """
     Save new clips to DATA_FILE
     """
-    with open(DATA_FILE, 'wb') as f:
-        json.dump(clips, f)
+    with open(DATA_FILE, 'w',encoding='utf8' ) as f:
+        json_string = json.dumps(clips, ensure_ascii=False ,indent=2)
+        f.write(json_string)
 
 
 def main():

--- a/kindle.py
+++ b/kindle.py
@@ -8,7 +8,7 @@ import re
 import json
 import argparse
 import dateparser
-from db_adapter import KindleClippingDB
+import db_adapter
 
 BOUNDARY = u"=========="
 
@@ -69,7 +69,7 @@ def get_clip(section):
 
 
 def main(kindle_clippings_file_path, json_db_path , is_overwrite):
-    db = KindleClippingDB(json_db_path)
+    db = db_adapter.KindleClippingDB(json_db_path)
 
     if is_overwrite:
         db.pure_all()

--- a/kindle.py
+++ b/kindle.py
@@ -84,7 +84,7 @@ def main(kindle_clippings_file_path, json_db_path , is_overwrite):
             clip = get_clip(section)
             try:
                 if clip and clip['date'] > latest_epoch:
-                    db.add_highlight(clip['content'],clip['title'],clip['author'],clip['position'],clip['position_end'],clip['date'])
+                    db.add_highlight(clip['content'],clip['title'],clip['author'],clip['date'],clip['position'],clip['position_end'])
             except KeyError:
                 print("missing minimum attribute {}".format(str(clip)))
 

--- a/kindle.py
+++ b/kindle.py
@@ -29,10 +29,10 @@ def get_clip(section):
         return
 
     clip['book'] = lines[0]
-    positon_match = re.search(r'(\d+)-\d+', lines[1])
-    if not positon_match:
+    position_match = re.search(r'(\d+)-(\d+)', lines[1])
+    if not position_match:
         return
-    position = positon_match.group(1)
+    position = position_match.group(1)
 
     date_match = re.search(r'Added on (.+)$', lines[1])
     if not date_match:
@@ -43,6 +43,7 @@ def get_clip(section):
     epoch = date_time_obj.timestamp()
     
     clip['position'] = int(position)
+    clip['position_end'] = int(position_match.group(2))
 
     clip['date'] = int(epoch)
 
@@ -103,7 +104,8 @@ def main(kindle_clippings_file_path, output_path , is_overwrite):
             clips[clip['book']][str(clip['position'])] = {'content': clip['content'],
                                                           'author':clip['author'],
                                                           'title':clip['title'],
-                                                          'date':clip['date']
+                                                          'date':clip['date'],
+                                                          'pos_end':clip['position_end']
                                                           }
 
     # remove key with empty value

--- a/kindle.py
+++ b/kindle.py
@@ -79,8 +79,8 @@ def main(kindle_clippings_file_path, json_db_path , is_overwrite):
         all_imported_highlights = db.highlights.search( (~ Query().not_by_imported.exists() ) )
         latest_epoch = 0
         if len(all_imported_highlights) > 0:
-            sorted(all_imported_highlights,key = lambda h : h['datetime_epoch'])
-            latest_epoch = all_imported_highlights[-1]['datetime_epoch']
+            sorted(all_imported_highlights,key = lambda h : h['epoch'])
+            latest_epoch = all_imported_highlights[-1]['epoch']
         for section in sections:
             clip = get_clip(section)
             try:

--- a/kindle.py
+++ b/kindle.py
@@ -28,7 +28,7 @@ def get_clip(section):
     if len(lines) != 3:
         return
 
-    clip['content'] = lines[2]
+    clip['content'] = lines[2].strip()
     
     title_author_content = lines[0]    
     reversed_str = ''.join(list(reversed([c for c in title_author_content])))
@@ -42,9 +42,8 @@ def get_clip(section):
     else:
         title = title_author_content
         author = ''
-    clip['title'] = title
-    clip['author'] = author
-    
+    clip['title'] = title.strip()
+    clip['author'] = author.strip()
 
     ##TODO: There are some cases where location be recorded in different format:
      ##  - 您在第 5 页（位置 #111）的书签 | 添加于 2017年2月23日星期四 上午8:00:46
@@ -52,7 +51,6 @@ def get_clip(section):
     if position_match:
         clip['position'] = int(position_match.group(1))
         clip['position_end'] = int(position_match.group(2))
-    
 
     #TODO: i18n support . for example , chinese version of Kindle have the below format
      ## - 您在位置 #180-180的标注 | 添加于 2017年2月22日星期三 下午7:06:30
@@ -66,10 +64,7 @@ def get_clip(section):
     #TODO: To recognise Notes & bookmark. notes have different format with highlight.
     #Note: - Your Note on page 187 | Location 2850 | Added on Wednesday, July 4, 2018 5:43:04 PM
     #Bookmark: - Your Bookmark on Location 15572 | Added on Tuesday, July 24, 2018 10:42:15 AM
-    
     return clip
-
-
 
 def main(kindle_clippings_file_path, json_db_path , is_overwrite):
     db = KindleClippingDB(json_db_path)

--- a/kindle.py
+++ b/kindle.py
@@ -8,7 +8,7 @@ import re
 import json
 import argparse
 import dateparser
-import collections
+import tinydb
 
 from io import open
 

--- a/kindle.py
+++ b/kindle.py
@@ -80,10 +80,15 @@ def main(kindle_clippings_file_path, json_db_path , is_overwrite):
     #import ipdb; ipdb.set_trace()        
     sections = get_sections(kindle_clippings_file_path)
     with db.db:
+        all_highlights = db.highlights.all()
+        latest_epoch = 0
+        if len(all_highlights) > 0:
+            sorted(all_highlights,key = lambda h : h['datetime_epoch'])
+            latest_epoch = all_highlights[-1]['datetime_epoch']
         for section in sections:
             clip = get_clip(section)
             try:
-                if clip:
+                if clip and clip['date'] > latest_epoch:
                     db.add_highlight(clip['content'],clip['title'],clip['author'],clip['position'],clip['position_end'],clip['date'])
             except KeyError:
                 print("missing minimum attribute {}".format(str(clip)))

--- a/output/.gitignore
+++ b/output/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
[io.open](https://docs.python.org/2/library/io.html#io.open) is the default open implementation in Python3 . The API support specified encoding when we opening a file , so we don't need encoding string manually before writing operation. 

Fortunately, we can use the API in Python 2. ( Python2.6+) . By leveraging it our code could work flawless both in Python2 & Python3. 